### PR TITLE
Fix transform function for amountCents

### DIFF
--- a/pinot-table-config.json
+++ b/pinot-table-config.json
@@ -76,7 +76,7 @@
       },
       {
         "columnName": "amountCents", 
-        "transformFunction": "CASE WHEN amount IS NULL THEN 0 ELSE CAST(amount AS LONG) END"
+        "transformFunction": "CASE WHEN amountCents IS NULL THEN 0 ELSE CAST(amountCents AS LONG) END"
       }
     ],
     "filterConfig": {


### PR DESCRIPTION
Correct `amountCents` transform function in Pinot config to use the defined field, resolving data ingestion errors.

The previous transform function incorrectly referenced a non-existent `amount` field, leading to `amountCents` being set to `0` and preventing proper data ingestion.