### PR TITLE
Fix upsert configuration issues

### DIFF
--- a/pinot-schema.json
+++ b/pinot-schema.json
@@ -110,7 +110,6 @@
     }
   ],
   "primaryKeyColumns": [
-    "paymentId",
-    "eventTimestamp"
+    "paymentId"
   ]
 }

--- a/pinot-table-config.json
+++ b/pinot-table-config.json
@@ -109,7 +109,7 @@
   "upsertConfig": {
     "mode": "FULL",
     "partialUpsertStrategies": {
-      "processingDurationMs": "INCREMENT",
+      "processingDurationMs": "OVERWRITE",
       "processingFeeCents": "OVERWRITE"
     }
   }


### PR DESCRIPTION
Correct Pinot upsert configuration to ensure proper record updates and accurate duration metric aggregation.

The `processingDurationMs` partial upsert strategy was changed from `INCREMENT` to `OVERWRITE` because duration metrics should reflect the latest value, not an accumulated sum. Additionally, `eventTimestamp` was removed from the primary key as its inclusion prevented updates to existing records for the same business identifier, hindering the intended `FULL` upsert behavior.