### PR TITLE
Fix conflicting index configurations for paymentId

### DIFF
--- a/pinot-table-config.json
+++ b/pinot-table-config.json
@@ -31,7 +31,6 @@
       "processingDurationMs"
     ],
     "bloomFilterColumns": [
-      "paymentId",
       "checkoutId",
       "idempotencyKey"
     ],


### PR DESCRIPTION
Remove `paymentId` from `bloomFilterColumns` to resolve conflicting index configurations not supported by Apache Pinot.