### PR TITLE
Fix primary key bug in schema

### DIFF
--- a/pinot-schema.json
+++ b/pinot-schema.json
@@ -110,6 +110,7 @@
     }
   ],
   "primaryKeyColumns": [
-    "paymentId"
+    "paymentId",
+    "eventTimestamp"
   ]
 }


### PR DESCRIPTION
Add `eventTimestamp` to the primary key in `pinot-schema.json` to prevent out-of-order events from overwriting newer data.

Previously, upsert operations based only on `paymentId` could lead to older, late-arriving events overwriting newer data. This change ensures that each payment event is uniquely identified by both `paymentId` and `eventTimestamp`, preserving chronological order and maintaining data integrity.